### PR TITLE
fix https query error when there is not https proxy in database

### DIFF
--- a/pkg/models/ip.go
+++ b/pkg/models/ip.go
@@ -1,5 +1,9 @@
 package models
 
+import (
+ "fmt"
+)
+
 // IP struct
 type IP struct {
 	ID    int64  `xorm:"pk autoincr" json:"-"`
@@ -94,8 +98,14 @@ func findAll(value string) ([]*IP, error) {
 			return tmpIp, err
 		}
 	case "https":
+               //test has https proxy on databases or not 
+               HasHttps := TestHttps()
+               if HasHttps == false {
+                    return tmpIp,nil
+                 }
 		err := x.Where("speed <= 1000 and type2=?", "https").Find(&tmpIp)
 		if err != nil {
+            fmt.Println(err.Error())
 			return tmpIp, err
 		}
 	default:
@@ -122,3 +132,18 @@ func update(ip IP) error {
 func Update(ip IP) error {
 	return update(ip)
 }
+
+//Test if have https proxy in database
+//if just test on mysql
+// dbName: ProxyPool
+// dbTableName: ip
+// select distinct if(exists(select * from ip where type2='https'),1,0) as a from ip;
+func TestHttps() bool {
+        has, err := x.Exist(&IP{Type2: "https"})
+        if err != nil {
+		return false
+         }
+        
+        return has
+} 
+        

--- a/pkg/models/ip.go
+++ b/pkg/models/ip.go
@@ -134,7 +134,7 @@ func Update(ip IP) error {
 }
 
 //Test if have https proxy in database
-//if just test on mysql
+//just test on mysql database
 // dbName: ProxyPool
 // dbTableName: ip
 // select distinct if(exists(select * from ip where type2='https'),1,0) as a from ip;

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -22,6 +22,7 @@ import (
 type Engine interface {
 	Delete(interface{}) (int64, error)
 	Exec(string, ...interface{}) (sql.Result, error)
+	Exist(...interface{}) (bool,error)
 	Find(interface{}, ...interface{}) error
 	Get(interface{}) (bool, error)
 	Id(interface{}) *xorm.Session
@@ -29,6 +30,7 @@ type Engine interface {
 	Insert(...interface{}) (int64, error)
 	InsertOne(interface{}) (int64, error)
 	Iterate(interface{}, xorm.IterFunc) error
+	Query(string, ...interface{}) (sql.Result, error)
 	Sql(string, ...interface{}) *xorm.Session
 	Table(interface{}) *xorm.Session
 	Where(interface{}, ...interface{}) *xorm.Session

--- a/pkg/storage/filter.go
+++ b/pkg/storage/filter.go
@@ -97,11 +97,12 @@ func ProxyRandom() (ip *models.IP) {
 // ProxyFind .
 func ProxyFind(value string) (ip *models.IP) {
 	ips, err := models.FindAll(value)
-	x := len(ips)
-	if (err != nil || x == 0){
+	if (err != nil){
 		clog.Warn(err.Error())
 		return models.NewIP()
 	}
+	x := len(ips)
+	clog.Warn("x = %d",x)
 	randomNum := RandInt(0, x)
 	clog.Info("[proxyFind] random num = %d", randomNum)
 	if randomNum == 0 {


### PR DESCRIPTION
修复当 数据库中不存在 https代理时候，查询出错问题
解决问题https://github.com/henson/proxypool/issues/31
