### PR TITLE
fix: 🐛 change github.com/go-xorm to xorm.io fix xorm parsing go

### DIFF
--- a/pkg/initial/initial.go
+++ b/pkg/initial/initial.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-clog/clog"
 	"github.com/go-ini/ini"
-	"github.com/go-xorm/xorm"
+	"xorm.io/xorm"
 	"github.com/henson/proxypool/pkg/models"
 	"github.com/henson/proxypool/pkg/setting"
 	"github.com/henson/proxypool/pkg/util"

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -11,18 +11,18 @@ import (
 
 	"github.com/go-clog/clog"
 	_ "github.com/go-sql-driver/mysql"
-        _ "github.com/mattn/go-sqlite3"
-	"github.com/go-xorm/core"
-	"github.com/go-xorm/xorm"
 	"github.com/henson/proxypool/pkg/setting"
 	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+	"xorm.io/core"
+	"xorm.io/xorm"
 )
 
 // Engine represents a XORM engine or session.
 type Engine interface {
 	Delete(interface{}) (int64, error)
 	Exec(string, ...interface{}) (sql.Result, error)
-	Exist(...interface{}) (bool,error)
+	Exist(...interface{}) (bool, error)
 	Find(interface{}, ...interface{}) error
 	Get(interface{}) (bool, error)
 	Id(interface{}) *xorm.Session
@@ -65,7 +65,7 @@ func LoadDatabaseInfo() {
 	switch DbCfg.Type {
 	case "sqlite3":
 		setting.UseSQLite3 = true
-                EnableSQLite3 = true
+		EnableSQLite3 = true
 	case "mysql":
 		setting.UseMySQL = true
 	case "postgres":


### PR DESCRIPTION
可能是因为xorm升级go mod，导致这边引用`github.com/go-xorm`会报错`github.com/go-xorm/core: github.com/go-xorm/core@v0.6.3: parsing go.mod`，现在改为`xorm.io`地址