### PR TITLE
Fix: panic on accessing nil error

### DIFF
--- a/getter/89ip.go
+++ b/getter/89ip.go
@@ -6,9 +6,10 @@ import (
 	//"fmt"
 	"github.com/go-clog/clog"
 
-	"github.com/henson/proxypool/pkg/models"
 	"regexp"
 	"strings"
+
+	"github.com/henson/proxypool/pkg/models"
 )
 
 //IP89 get ip from www.89ip.cn
@@ -16,7 +17,7 @@ func IP89() (result []*models.IP) {
 	clog.Info("89IP] start test")
 	var ExprIP = regexp.MustCompile(`((25[0-5]|2[0-4]\d|((1\d{2})|([1-9]?\d)))\.){3}(25[0-5]|2[0-4]\d|((1\d{2})|([1-9]?\d)))\:([0-9]+)`)
 	pollURL := "http://www.89ip.cn/tqdl.html?api=1&num=100&port=&address=%E7%BE%8E%E5%9B%BD&isp="
-	
+
 	resp, err := http.Get(pollURL)
 	if err != nil {
 		clog.Warn(err.Error())
@@ -24,7 +25,7 @@ func IP89() (result []*models.IP) {
 	}
 
 	if resp.StatusCode != 200 {
-		clog.Warn(err.Error())
+		clog.Warn("failed to get proxies from 89ip, http status: %d, error: %v", resp.StatusCode, err)
 		return
 	}
 	defer resp.Body.Close()
@@ -40,9 +41,6 @@ func IP89() (result []*models.IP) {
 		result = append(result, ip)
 	}
 
-	
-
 	clog.Info("89IP done.")
 	return
 }
-

--- a/pkg/storage/filter.go
+++ b/pkg/storage/filter.go
@@ -87,7 +87,7 @@ func ProxyRandom() (ip *models.IP) {
 	x := len(ips)
 	clog.Warn("len(ips) = %d", x)
 	if err != nil || x == 0 {
-		clog.Warn(err.Error())
+		clog.Warn("failed to get random ip, len(ips) %d, error %v", x, err)
 		return models.NewIP()
 	}
 	randomNum := RandInt(0, x)


### PR DESCRIPTION
## panic 1
```
goroutine 83 [running]:
github.com/henson/proxypool/getter.IP89(0x0, 0x0, 0x0)
	/Users/vicxiao/workspace/go/github/proxypool/getter/89ip.go:27 +0x453
main.run.func1(0xc0002ba1e0, 0xc0002a6480, 0x4768f98)
```

sample output after fix

```
2020/05/07 11:36:45 [ WARN] failed to get proxies from 89ip, http status: 503, error: <nil>
```

## panic 2

```
2020/05/07 11:37:32 http: panic serving [::1]:53613: runtime error: invalid memory address or nil pointer dereference
goroutine 208 [running]:
...
	/Users/vicxiao/workspace/go/github/proxypool/pkg/storage/filter.go:90 +0xc6
github.com/henson/proxypool/api.ProxyHandler(0x4818d40, 0xc000158620, 0xc0002a0f00)
```
sample output after fix

```
2020/05/07 11:44:55 [ WARN] failed to get random ip, len(ips) 0, error <nil>
```

BTW, I could not get any proxy to use.
